### PR TITLE
DCT-20255: Fixes for ActiveDirectory standard debacle

### DIFF
--- a/lib/net/ldap/filter.rb
+++ b/lib/net/ldap/filter.rb
@@ -646,7 +646,7 @@ class Net::LDAP::Filter
   ##
   # Converts escaped characters (e.g., "\\28") to unescaped characters
   # @note slawson20170317: Don't attempt to unescape 16 byte binary data which we assume are objectGUIDs
-  # The binary form of 5936AE79-664F-44EA-BCCB-5C39399514C6 triggers a BINARY -> UTF-8 conversion error        
+  # The binary form of 5936AE79-664F-44EA-BCCB-5C39399514C6 triggers a BINARY -> UTF-8 conversion error
   def unescape(right)
     right = right.to_s
     if right.length == 16 && right.encoding == Encoding::BINARY
@@ -759,10 +759,15 @@ class Net::LDAP::Filter
         scanner.scan(/\s*/)
         if op = scanner.scan(/<=|>=|!=|:=|=/)
           scanner.scan(/\s*/)
-          if value = scanner.scan(/(?:[-\[\]{}\w*.+\/:@=,#\$%&!'^~\s\xC3\x80-\xCA\xAF]|[^\x00-\x7F]|\\[a-fA-F\d]{2})+/u)
+          if value = scanner.scan(/(?:[-\[\]{}\w*.+\/:@=,#\$%&!'^~\s\xC3\x80-\xCA\xAF]|[^\x00-\x7F]|\x5C(?:[\x20-\x23]|[\x2B\x2C]|[\x3B-\x3E]|\x5C)|\\[a-fA-F\d]{2})+/u)
             # 20100313 AZ: Assumes that "(uid=george*)" is the same as
             # "(uid=george* )". The standard doesn't specify, but I can find
             # no examples that suggest otherwise.
+            #
+            # 20190710 CmdrClueless
+            # RFC-4514, Section 2.4 adds to the scanner regex above
+            #     \x5C(?:[\x20-\x23]|[\x2B\x2C]|[\x3B-\x3E]|\x5C)
+            #   This is commonly done by ActiveDirectory, with a DN such as CN=#Supers,CN=Users,DC=test,DC=com
             value.strip!
             case op
             when "="

--- a/lib/net/ldap/version.rb
+++ b/lib/net/ldap/version.rb
@@ -1,5 +1,5 @@
 module Net
   class LDAP
-    VERSION = "0.16.1"
+    VERSION = "0.16.1-sunbirddcim.1"
   end
 end


### PR DESCRIPTION
As part of [RFC4514](https://tools.ietf.org/html/rfc4514) section 2.4, it's permissible to prefix some characters with the backslash (\) symbol instead of using the standard format of `\xx` where `xx` is the hexadecimal code for the character in question. This was exposed when a group in Active Directory (AD) was created with a `#` symbol.

Consider the DN `CN=#Supers,DC=foo,DC=bar,DC=com`. AD sends this as `CN=\#Supers,DC=foo,DC=bar,DC=com`, which is an alternative format according to the spec. However the `#` symbol is hex code _23_. This mean the standardized form via the spec should result in `CN=\23Supers,DC=foo,DC=bar,DC=com`. Unfortunately during testing AD will return the record, *if and only if*, the alternative format is used.

The relevant section of the RFC for this change follows

>Each octet of the character to be escaped is replaced by a backslash
>and two hex digits, which form a single octet in the code of the
>character.  Alternatively, if and only if the character to be escaped
> is one of
>
>      ' ', '"', '#', '+', ',', ';', '<', '=', '>', or '\'
>      (U+0020, U+0022, U+0023, U+002B, U+002C, U+003B,
>       U+003C, U+003D, U+003E, U+005C, respectively)
>
>it can be prefixed by a backslash ('\' U+005C).
